### PR TITLE
Add OWNERS file

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,0 +1,29 @@
+approvers:
+  - andresllh
+  - bartoszmajsak
+  - brettmthompson
+  - danielezonca
+  - hdefazio
+  - israel-hdez
+  - Jooho
+  - mholder6
+  - mwaykole
+  - pierDipi
+  - rnetser
+  - spolti
+  - terrytangyuan
+  - VedantMahabaleshwarkar
+reviewers:
+  - andresllh
+  - bartoszmajsak
+  - brettmthompson
+  - hdefazio
+  - israel-hdez
+  - Jooho
+  - mholder6
+  - mwaykole
+  - pierDipi
+  - rnetser
+  - spolti
+  - terrytangyuan
+  - VedantMahabaleshwarkar


### PR DESCRIPTION
## Description
Add the OWNERS file. This is a requirement to onboard the repo to the openshift ci 
[RHOAIENG-32966](https://issues.redhat.com/browse/RHOAIENG-32966) 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Introduced repository ownership configuration via an OWNERS file to standardize PR governance. Defines approvers and reviewers to streamline code review responsibilities across the project. This change clarifies who can approve and who can review pull requests, improving transparency and consistency in the review process. No user-facing functionality is affected or settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->