### PR TITLE
[RHOAIENG-44309] [RHOAIENG-42057] Update Dockerfile to fix 2 CVEs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,11 @@ COPY internal/ internal/
 RUN CGO_ENABLED=1 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o bin/llm-d-routing-sidecar cmd/cmd.go
 
 FROM registry.access.redhat.com/ubi9/ubi:latest
+RUN dnf install -y python3-pip && \
+    dnf clean all && \
+    pip3 install --upgrade pip && \
+    # urllib3>=2.6.0 is required to fix several security issues
+    pip install "urllib3>=2.6.3" --no-cache-dir
 WORKDIR /
 COPY --from=builder /workspace/bin/llm-d-routing-sidecar /app/llm-d-routing-sidecar
 USER 65532:65532


### PR DESCRIPTION
Fixing CVEs 
CVE-2025-66471
CVE-2025-66418

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added Python tooling to the runtime environment so Python utilities are available at runtime.
  * Upgraded urllib3 to a security-fix version to address known vulnerabilities and improve runtime security.
  * No changes to public or exported interfaces.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->